### PR TITLE
io.greenfire.Greenery v0.9.8 update, Wayland Error features=UseOzoneP…

### DIFF
--- a/io.greenfire.Greenery.appdata.xml
+++ b/io.greenfire.Greenery.appdata.xml
@@ -22,7 +22,26 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release version="0.9.7" date="2024-02-25"/>
+    <release version="0.9.8" date="2024-04-01">
+    <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.8</url>
+      <description >
+          <ul>
+            <li>Support for the Terra Classic(LUNC) blockchain added to the dashboard</li>
+            <li>Added ERC20 tokens AAVE, AMP, AXS, COMP, CRV, MANA, NMR, PEPE, SALT, SAND, SHIB, and UNI</li>
+            <li>Show password feature now present when linking an email in settings</li>
+            <li>Address QR codes can now be scanned into the dashboard send form address field</li>
+          </ul>
+      </description>
+    </release>
+    <release version="0.9.7" date="2024-02-25">
+    <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.7</url>
+      <description >
+          <ul>
+            <li>Two-factor authentication setting added for web3 requests</li>
+            <li>Crypto can now be purchased using the Transak widget on the Quick Exchange page</li>
+          </ul>
+      </description>
+    </release>
   </releases>
   <update_contact>hello_at_greenfire.io</update_contact> 
   <content_rating type="oars-1.1"/>

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -13,7 +13,6 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
         "--socket=wayland",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
@@ -36,8 +35,16 @@
                     "type": "script", 
                     "dest-filename": "greenery",
                     "commands": [
-                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper /app/main/greenery \"$@\""
+                        "FLAGS=''",
+                        "if [[ $XDG_SESSION_TYPE == \"wayland\" && -e \"$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY\" ]]",
+                        "then",
+                        "    FLAGS=\"$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations\"",
+                        "    if  [ -c /dev/nvidia0 ]",
+                        "    then",
+                        "        FLAGS=\"$FLAGS --disable-gpu-sandbox\"",
+                        "    fi",
+                        "fi",
+                        "env TMPDIR=\"$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.greenfire.Greenery}\" zypak-wrapper /app/main/greenery $FLAGS \"$@\""
                     ]
                 },
                 {

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -14,6 +14,8 @@
         "--share=ipc",
         "--share=network",
         "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri"
     ],
@@ -40,8 +42,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.7/Greenery-linux-x64-0.9.7.zip",
-                    "sha256": "b230efd545589effebdade8f20162801b71733f2f267c1f9a2ad7e285bc042fd", 
+                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.8/Greenery-linux-x64-0.9.8.zip",
+                    "sha256": "1e36d2d4697a99e384720fcea2f6116afef13fa3e199445638dd4a9080457236", 
                     "dest": "main",
                     "dest-filename": "greenery.zip",
                     "x-checker-data": {


### PR DESCRIPTION
App update to v0.9.8, adding new options for Wayland socket and x11 fallback.

Also came across a new issue with running Greenery from a Flathub local build.

flatpak run io.greenfire.Greenery 

[2:0403/170448.706406:ERROR:ozone_platform_x11.cc(247)] Missing X server or $DISPLAY
[2:0403/170448.706429:ERROR:env.cc(226)] The platform failed to initialize.  Exiting.

I can run the app from the binary build (outside of Flathub runtime) with:

$: ./greenery --ozone-platform-hint=auto

Found this issue that details more:

https://github.com/element-hq/element-web/issues/32192

Need to find the best way to provide a fix. In addition using the ozone auto option does not allow me to resize the Greenery App Window.

Also I left socket=x11 in the json config file.  This was showing Legacy Windowing System in App Details but need to see if fallback option will remove this. Otherwise remove the x11 option.
