### PR TITLE
working on 0.9.11 update and running into system dbus errors locally

### DIFF
--- a/io.greenfire.Greenery.appdata.xml
+++ b/io.greenfire.Greenery.appdata.xml
@@ -35,7 +35,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release version="0.9.11" date="2024-04-09">
+    <release version="0.9.11" date="2025-04-09">
     <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.11</url>
       <description >
           <ul>

--- a/io.greenfire.Greenery.appdata.xml
+++ b/io.greenfire.Greenery.appdata.xml
@@ -35,7 +35,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release version="0.9.11" date="2024-10-16">
+    <release version="0.9.11" date="2024-04-09">
     <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.11</url>
       <description >
           <ul>

--- a/io.greenfire.Greenery.appdata.xml
+++ b/io.greenfire.Greenery.appdata.xml
@@ -35,6 +35,18 @@
     <category>Utility</category>
   </categories>
   <releases>
+    <release version="0.9.11" date="2024-10-16">
+    <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.11</url>
+      <description >
+          <ul>
+            <li>Exported data can now be saved using encrypted .genc files</li>
+            <li>Encrypt/Decrypt files using the Storage page</li>
+            <li>CSV exports are now properly formatted on Dashboard > History, History > Global/Journal, and Exchanges > Balance/History</li>
+            <li>PDF exports have been updated in Dashboard > History and History > Global/Journal</li>
+            <li>Tezos Domains resolution service updated for continued support</li>
+          </ul>
+      </description>
+    </release>
     <release version="0.9.10" date="2024-08-19">
     <url type="details">https://github.com/GreenfireInc/Releases.Greenery/releases/tag/v0.9.10</url>
       <description >

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -16,8 +16,7 @@
         "--socket=wayland",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
-        "--device=dri",
-        "--system-talk-name=org.freedesktop.DBus"
+        "--device=dri"
     ],
     "modules": [
         {

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -16,7 +16,8 @@
         "--socket=wayland",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
-        "--device=dri"
+        "--device=dri",
+        "--system-talk-name=org.freedesktop.DBus"
     ],
     "modules": [
         {
@@ -49,8 +50,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.10/Greenery-linux-x64-0.9.10.zip",
-                    "sha256": "4daf178997843d36ab351aeda5bd62e2d3c5ba72955fe4d3179c0bb5dabb633e",
+                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.11/Greenery-linux-x64-0.9.11.zip",
+                    "sha256": "424c47b067feb0183e9348a622f91b6befb5617623220107f6541dedac58da93",
                     "dest": "main",
                     "dest-filename": "greenery.zip",
                     "x-checker-data": {

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -1,9 +1,9 @@
 {
     "app-id": "io.greenfire.Greenery",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "23.08",
+    "base-version": "24.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "greenery",
     "separate-locales": false,
@@ -24,6 +24,13 @@
         {
             "name": "greenery",
             "buildsystem": "simple",
+            "build-options": {
+                "env": {
+                    "LANG": "en_US.UTF-8",
+                    "LC_ALL": "en_US.UTF-8",
+                    "TZ": "UTC"
+                }
+            },
             "build-commands": [
                 "install -Dm644 io.greenfire.Greenery.desktop /app/share/applications/io.greenfire.Greenery.desktop",
                 "install -Dm644 io.greenfire.Greenery.appdata.xml /app/share/appdata/io.greenfire.Greenery.appdata.xml",
@@ -51,15 +58,15 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.11/Greenery-linux-x64-0.9.11.zip",
-                    "sha256": "6e5ba7f89057e3d114153174f4596d04f7911725a8903088ef6c52ff7c4fdfc3",
+                    "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.11/Greenery-linux-x64-0.9.11.tar.gz",
+                    "sha256": "e0f257160380d9d510dcf1cfc86a3f36570b3fb221a02830049d01e652021eef",
                     "dest": "main",
-                    "dest-filename": "greenery.zip",
+                    "dest-filename": "greenery.tar.gz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://github.com/GreenfireInc/Releases.Greenery/releases",
                         "version-pattern": "https://github.com/GreenfireInc/Releases.Greenery/releases/hashes-Greenery.([\\d\\.-]+).txt",
-                        "url-template": "https://github.com/GreenfireInc/Releases.Greenery/releases/Greenery-linux-x64.$version.zip"
+                        "url-template": "https://github.com/GreenfireInc/Releases.Greenery/releases/Greenery-linux-x64.$version.tar.gz"
                     }
                 },
                 {

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -16,7 +16,8 @@
         "--socket=wayland",
         "--socket=fallback-x11",
         "--socket=pulseaudio",
-        "--device=dri"
+        "--device=dri",
+        "--filesystem=host"
     ],
     "modules": [
         {
@@ -50,7 +51,7 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v0.9.11/Greenery-linux-x64-0.9.11.zip",
-                    "sha256": "424c47b067feb0183e9348a622f91b6befb5617623220107f6541dedac58da93",
+                    "sha256": "6e5ba7f89057e3d114153174f4596d04f7911725a8903088ef6c52ff7c4fdfc3",
                     "dest": "main",
                     "dest-filename": "greenery.zip",
                     "x-checker-data": {

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -17,7 +17,6 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri",
-        "--env=ELECTRON_ENABLE_LOGGING=1",
         "--filesystem=host"
     ],
     "modules": [

--- a/io.greenfire.Greenery.json
+++ b/io.greenfire.Greenery.json
@@ -17,6 +17,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri",
+        "--env=ELECTRON_ENABLE_LOGGING=1",
         "--filesystem=host"
     ],
     "modules": [


### PR DESCRIPTION
- Fedora installed updates while I was booting into it, I have done additional updates and also updated flatpak and related utilities
- added system dbus perm arg and Greenery is not launching and no longer displays dbus error
- will test remote Flathub Build of Greenery.  
- Fedora updating the system has caused bugs on multiple occasions in the past